### PR TITLE
Don't use pseudo-random functions for getting phrases

### DIFF
--- a/alert.py
+++ b/alert.py
@@ -25,7 +25,8 @@ def get_phrase():
     with open('phrases.json') as phrase_r:
         phrase = json.load(phrase_r)
         phrases = phrase['phrases']
-        return random.choice(phrases)
+        r = random.SystemRandom()
+        return r.choice(phrases)
 
 def get_config():
     global users


### PR DESCRIPTION
This can lead to favoring some phrases more than others. We need to switch to os.urandom() instead..